### PR TITLE
custom filename for massConvert command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ default-*.json
 
 # Visual Studio Code
 .vscode
+
+#prevent potential private schemas publishing 
+*.cds

--- a/README.md
+++ b/README.md
@@ -1067,18 +1067,19 @@ Options:
 ### massConvert
 
 ```shell
-hana-cli massConvert [schema] [table]  
+hana-cli massConvert [schema] [table]
 
 Convert a group of tables to CDS or HDBTable format
 
 Options:
-  --admin, -a, --Admin    Connect via admin (default-env-admin.json)
+  -a, --admin, --Admin        Connect via admin (default-env-admin.json)
                                                       [boolean] [default: false]
-  --table, -t, --Table    Database Table                 [string] [default: "*"]
-  --schema, -s, --Schema  schema        [string] [default: "**CURRENT_SCHEMA**"]
-  --limit, -l             Limit results                  [number] [default: 200]
-  --folder, -f, --Folder  DB Module Folder Name         [string] [default: "./"]
-  --output, -o, --Output  Output Format for inspection
+  -t, --table, --Table        Database Table             [string] [default: "*"]
+  -s, --schema, --Schema      schema    [string] [default: "**CURRENT_SCHEMA**"]
+  -l, --limit                 Limit results              [number] [default: 200]
+  -f, --folder, --Folder      DB Module Folder Name     [string] [default: "./"]
+  -n, --filename, --Filename  File name                                 [string]
+  -o, --output, --Output      Output Format for inspection
                           [string] [choices: "hdbtable", "cds"] [default: "cds"]
 ```
 

--- a/_i18n/messages.properties
+++ b/_i18n/messages.properties
@@ -131,3 +131,4 @@ upsInstances=List all Cloud Foundry user provided service instances in your targ
 hc_instance_name=SAP HANA Cloud Instance name
 hcStart=Start SAP HANA Cloud instance
 hcStop=Stop SAP HANA Cloud instance
+filename=File name

--- a/bin/massConvert.js
+++ b/bin/massConvert.js
@@ -38,6 +38,11 @@ exports.builder = {
         default: './',
         desc: bundle.getText("folder")
     },
+    filename: {
+        alias: ['n', 'Filename'],
+        type: 'string',
+        desc: bundle.getText("filename")
+    },
     output: {
         alias: ['o', 'Output'],
         choices: ["hdbtable", "cds"],
@@ -83,6 +88,10 @@ exports.handler = function (argv) {
                 type: 'string',
                 required: true
             },
+            filename: {
+                description: bundle.getText("filename"),
+                type: 'string'
+            },
             output: {
                 description: bundle.getText("outputType"),
                 type: 'string',
@@ -100,8 +109,6 @@ exports.handler = function (argv) {
         getTables(result);
     });
 }
-
-
 async function getTables(result) {
     const db = new dbClass(await dbClass.createConnectionFromEnv(dbClass.resolveEnv(result)));
 
@@ -109,7 +116,7 @@ async function getTables(result) {
     console.log(`Schema: ${schema}, Table: ${result.table}`);
 
     let results = await getTablesInt(schema, result.table, db, result.limit);
-    const dbInspect = require("../utils/dbInspect")
+    const dbInspect = require("../utils/dbInspect")    
 
     switch (result.output) {
         case 'hdbtable': {
@@ -126,10 +133,13 @@ async function getTables(result) {
                 base64: false,
                 compression: "DEFLATE"
             });
-            fs.writeFile(dir + 'export.zip', data, 'binary', (err) => {
+            
+            let filename = result.filename || dir + 'export.zip';
+
+            fs.writeFile(filename, data, 'binary', (err) => {
                 if (err) throw err;
             });
-            console.log(`Content written to: ${dir}export.zip`);
+            console.log(`Content written to: ${filename}`);
             break
         }
         default: {
@@ -143,10 +153,11 @@ async function getTables(result) {
             let fs = require('fs');
             let dir = result.folder;
             !fs.existsSync(dir) && fs.mkdirSync(dir);
-            fs.writeFile(dir + 'export.cds', cdsSource, (err) => {
+            let filename = result.filename || dir + 'export.cds';
+            fs.writeFile(filename, cdsSource, (err) => {
                 if (err) throw err;
             });
-            console.log(`Content written to: ${dir}export.cds`);
+            console.log(`Content written to: ${filename}`);
             break
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hana-cli",
-  "version": "1.202102.3",
+  "version": "1.202102.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Adds option to provide custom filename for generated file:
`hana-cli massConvert SFLIGHT -n sflight.cds -a`

With this option is possible to generate several schemas in one folder

Resolves #25 