### PR TITLE
Solved serviceKey err "base.env is not a function"

### DIFF
--- a/bin/connectViaServiceKey.js
+++ b/bin/connectViaServiceKey.js
@@ -128,7 +128,7 @@ async function setKeyDetails(input) {
 }
 
 async function saveEnv(options, input) {
-  base.env('saveEnv')
+  base.debug('saveEnv')
   let defaultEnv = {}
   defaultEnv.VCAP_SERVICES = {}
   defaultEnv.VCAP_SERVICES.hana = [{


### PR DESCRIPTION
Running "hana-cli serviceKey" I get error:
TypeError: base.env is not a function

Replaced base.env() with base.debug()