### PR TITLE
Segmentation fault on WSL

### DIFF
--- a/bin/connectViaServiceKey.js
+++ b/bin/connectViaServiceKey.js
@@ -155,13 +155,14 @@ async function saveEnv(options, input) {
   base.debug(defaultEnv.VCAP_SERVICES)
   try {
     const dbClass = require("sap-hdbext-promisfied")
-    const db = new dbClass(await dbClass.createConnection(options))
+    const clientConnection = await dbClass.createConnection(options)
+    const db = new dbClass(clientConnection)
     let results = await db.execSQL(`SELECT CURRENT_USER AS "Current User", CURRENT_SCHEMA AS "Current Schema" FROM DUMMY`);
     console.table(results)
 
     let resultsSession = await db.execSQL(`SELECT * FROM M_SESSION_CONTEXT WHERE CONNECTION_ID = (SELECT SESSION_CONTEXT('CONN_ID') FROM "DUMMY")`);
     console.table(resultsSession)
-
+    clientConnection.disconnect()
   } catch (error) {
     base.error(error)
   }

--- a/bin/hostInformation.js
+++ b/bin/hostInformation.js
@@ -14,7 +14,8 @@ async function hostInfo(prompts) {
     base.setPrompts(prompts)
     const dbClass = require("sap-hdbext-promisfied")
     const conn = require("../utils/connections")
-    const dbStatus = new dbClass(await conn.createConnection(prompts))
+    const clientConnection = await conn.createConnection(prompts)
+    const dbStatus = new dbClass(clientConnection)
 
     let results = await dbStatus.execSQL(
       `SELECT * FROM M_HOST_INFORMATION
@@ -25,6 +26,7 @@ async function hostInfo(prompts) {
       `SELECT * FROM M_HOST_RESOURCE_UTILIZATION
       ORDER BY HOST`)
     base.outputTable(results)
+    clientConnection.disconnect()
     return base.end()
   } catch (error) {
     base.error(error)

--- a/bin/users.js
+++ b/bin/users.js
@@ -40,12 +40,14 @@ async function getUsers(prompts) {
     base.setPrompts(prompts)
     const dbClass = require("sap-hdbext-promisfied")
     const conn = require("../utils/connections")
-    const db = new dbClass(await conn.createConnection(prompts))
+    const clientConnection = await conn.createConnection(prompts)
+    const db = new dbClass(clientConnection)
 
     base.debug(`${base.bundle.getText("user")}: ${prompts.user}`)
 
     let results = await getUsersInt(prompts.user, db, prompts.limit)
     base.outputTable(results)
+    clientConnection.disconnect()
     return base.end()
   } catch (error) {
     base.error(error)


### PR DESCRIPTION
All the commands on WSL do the jobs correctly but then they get terminated with segmentation fault.
Doing a hana client disconnect() solved the problem, if it is ok I can change all the commands

```
> hana-cli serviceKey
Input: CF/XS Service Instance Name:  test-hanatrial-db
Input: CF/XS Service Key Name:  hana-cli
Service Key hana-cli created
Getting key hana-cli for service instance test-hanatrial-db as sbarzaghi@alteanet.it...
Current User                                                   Current Schema
-------------------------------------------------------------  --------------------------------
E56F46F086A64647BBE8C42804FF5AC2_0ERYBTS8G58PZMBDPDQUN11M5_RT  E56F46F086A64647BBE8C42804FF5AC2

HOST                                  PORT   CONNECTION_ID  KEY                 VALUE                                                          SECTION
------------------------------------  -----  -------------  ------------------  -------------------------------------------------------------  -------
0b0f5d1a-e092-4151-ac37-6e03c3ffffff  30040  202141         APPLICATION         node                                                           SYSTEM
0b0f5d1a-e092-4151-ac37-6e03c3ffffff  30040  202141         APPLICATIONUSER     sbarzaghi                                                      SYSTEM
0b0f5d1a-e092-4151-ac37-6e03c3ffffff  30040  202141         XS_APPLICATIONUSER  E56F46F086A64647BBE8C42804FF5AC2_0ERYBTS8G58PZMBDPDQUN11M5_RT  SYSTEM
0b0f5d1a-e092-4151-ac37-6e03c3ffffff  30040  202141         PROTOCOL_VERSION    4.1 (6, 8)                                                     SYSTEM
0b0f5d1a-e092-4151-ac37-6e03c3ffffff  30040  202141         DRIVERVERSION       2.8.20                                                         USER

The default-env.json file was saved with connection details!
Segmentation fault
```

