### PR TITLE
fixes #105 command hc via cf was broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ yarn.lock
 
 # added by cds bind
 .cdsrc-private.json
+
+# macos
+.DS_Store

--- a/bin/hanaCloudInstances.js
+++ b/bin/hanaCloudInstances.js
@@ -98,7 +98,7 @@ export async function listInstances(prompts) {
             //console.log(error)
         }
         base.debug(results)
-        if (results && results.resource) {
+        if (results && results.resources) {
             // @ts-ignore
             for (let item of results.resources) {
                 let outputItem = {}


### PR DESCRIPTION
there was a small bug in the file hanaCloudInstances.js which was the cause that no output was shown after the successful. With this fixes it now looks good again, also when  cf cli is used instead of btp cli:

```shell
node bin/cli.js hc 
Debugger attached.
Checking at the BTP Level
Checking at the CF Level
Name: BLUE01
Create At: Fri Oct 28 2022 12:49:58 GMT+0000 (Coordinated Universal Time)
Status: 👟 Running
Last Operation: update succeeded @ Wed Mar 15 2023 05:36:43 GMT+0000 (Coordinated Universal Time)
SAP HANA Cockpit: https://hana-cockpit-001.cfapps.us10.hana.ondemand.com/start?......
```