### PR TITLE
ci(ospo): gate npm publish behind environment + branch ruleset prep

### DIFF
--- a/.github/workflows/release-agent-instructions.yml
+++ b/.github/workflows/release-agent-instructions.yml
@@ -119,6 +119,9 @@ jobs:
       needs.test.result == 'success' &&
       (needs.prepare.result == 'success' || needs.resolve-version.result == 'success')
     runs-on: ubuntu-latest
+    environment:
+      name: npm-publish
+      url: https://www.npmjs.com/package/hana-cli-agent-instructions/v/${{ steps.ver.outputs.version }}
     steps:
       - name: Determine version
         id: ver

--- a/.github/workflows/release-hana-cli.yml
+++ b/.github/workflows/release-hana-cli.yml
@@ -138,6 +138,9 @@ jobs:
       needs.test.result == 'success' &&
       (needs.prepare.result == 'success' || needs.resolve-version.result == 'success')
     runs-on: ubuntu-latest
+    environment:
+      name: npm-publish
+      url: https://www.npmjs.com/package/hana-cli/v/${{ steps.ver.outputs.version }}
     steps:
       - name: Determine version
         id: ver


### PR DESCRIPTION
## Summary

OSPO compliance changes — part 1 (workflow side):

- **release-hana-cli.yml** publish job now runs in the `npm-publish` GitHub Environment
- **release-agent-instructions.yml** publish job now runs in the `npm-publish` GitHub Environment

The `npm-publish` environment was created out-of-band via the GitHub API with:
- **Required reviewer**: @jung-thomas — must manually approve every npm publish
- **Deployment branch policy**: only tags matching `v*` or `agent-v*` can deploy
- **Secret scope** (next step, manual): `NPM_TOKEN` should be moved from repo-level to environment-level so the token is unavailable to any other workflow / job

## Why

Repo-level secrets are accessible to *every* workflow run, including dependabot PR runs and any future workflow added by a contributor. Scoping `NPM_TOKEN` to an environment with required reviewers means a malicious workflow change can no longer exfil the token without a human approving the deployment.

## Follow-ups (not in this PR)

1. Move `NPM_TOKEN` from repo secrets → `npm-publish` environment secrets (requires the actual token value)
2. Apply branch protection ruleset on `main` (will be done after this PR merges)

## Test plan

- [ ] Verify both workflows still parse: `gh workflow view release-hana-cli.yml` and `gh workflow view release-agent-instructions.yml`
- [ ] Next release tag push will pause at the `Publish to npm` job awaiting reviewer approval — confirm the gate appears
- [ ] After approval, confirm `npm publish` succeeds with the environment-scoped token