### PR TITLE
fix(i18n): add missing vscode + error.cfNotLoggedIn keys to all locales

### DIFF
--- a/_i18n/messages_de.properties
+++ b/_i18n/messages_de.properties
@@ -633,7 +633,8 @@ error.massConvertFailed=Fehler in massConvert: {0}
 error.parseError=Fehler: {0}
 error.jsonParseError=JSON-Parsefehler
 error.cfServicePlansRequired=Serviceplan(e) müssen angegeben werden
-error.cfTargetUnavailable=Aktueller Space oder Organisation kann nicht ermittelt werden\nerror.cfNotLoggedIn=Nicht bei Cloud Foundry angemeldet. Bitte zuerst 'cf login' ausführen und dann erneut versuchen
+error.cfTargetUnavailable=Aktueller Space oder Organisation kann nicht ermittelt werden
+error.cfNotLoggedIn=Nicht bei Cloud Foundry angemeldet. Bitte zuerst 'cf login' ausführen und dann erneut versuchen
 error.cfServiceInstanceNameRequired=Name der Service-Instanz muss eine nicht leere Zeichenkette sein
 error.cfHanaInstanceGuidRequired=HANA-Instanz-GUID muss eine nicht leere Zeichenkette sein
 error.cfHanaInstanceNameRequired=HANA-Instanzname muss eine nicht leere Zeichenkette sein
@@ -1638,3 +1639,4 @@ mcpServerStatusBuildHint=MCP server is not built. Build it first:
 
 rowsAffected=Betroffene Zeilen: {0}
 stmtExecutedNoResultSet=Anweisung erfolgreich ausgeführt (kein Ergebnis).
+vscode=hana-cli-VSCode-Erweiterung verwalten (Installieren, Deinstallieren, Status)

--- a/_i18n/messages_es.properties
+++ b/_i18n/messages_es.properties
@@ -633,7 +633,8 @@ error.massConvertFailed=Error en massConvert: {0}
 error.parseError=Error: {0}
 error.jsonParseError=Error de análisis JSON
 error.cfServicePlansRequired=Se deben especificar plan(es) de servicio
-error.cfTargetUnavailable=No se pudo determinar el espacio u organización actuales\nerror.cfNotLoggedIn=No ha iniciado sesión en Cloud Foundry. Ejecute 'cf login' primero y vuelva a intentarlo
+error.cfTargetUnavailable=No se pudo determinar el espacio u organización actuales
+error.cfNotLoggedIn=No ha iniciado sesión en Cloud Foundry. Ejecute 'cf login' primero y vuelva a intentarlo
 error.cfServiceInstanceNameRequired=El nombre de instancia de servicio debe ser una cadena no vacía
 error.cfHanaInstanceGuidRequired=El GUID de instancia HANA debe ser una cadena no vacía
 error.cfHanaInstanceNameRequired=El nombre de instancia HANA debe ser una cadena no vacía
@@ -1638,3 +1639,4 @@ mcpServerStatusBuildHint=MCP server is not built. Build it first:
 
 rowsAffected=Filas afectadas: {0}
 stmtExecutedNoResultSet=Sentencia ejecutada correctamente (sin conjunto de resultados).
+vscode=Gestionar la extensión de VSCode de hana-cli (instalar, desinstalar, estado)

--- a/_i18n/messages_fr.properties
+++ b/_i18n/messages_fr.properties
@@ -634,6 +634,7 @@ error.parseError=Erreur : {0}
 error.jsonParseError=Erreur d’analyse JSON
 error.cfServicePlansRequired=Le(s) plan(s) de service doivent être spécifiés
 error.cfTargetUnavailable=Impossible de déterminer l’espace ou l’organisation actuels
+error.cfNotLoggedIn=Non connecté à Cloud Foundry. Veuillez d’abord exécuter 'cf login', puis réessayer cette opération
 error.cfServiceInstanceNameRequired=Le nom de l’instance de service doit être une chaîne non vide
 error.cfHanaInstanceGuidRequired=Le GUID de l’instance HANA doit être une chaîne non vide
 error.cfHanaInstanceNameRequired=Le nom de l’instance HANA doit être une chaîne non vide
@@ -1639,3 +1640,4 @@ cds.swagger.error=Warning: Swagger UI setup failed: {0}
 
 rowsAffected=Lignes affectées : {0}
 stmtExecutedNoResultSet=Instruction exécutée avec succès (pas de jeu de résultats).
+vscode=Gérer l’extension VSCode hana-cli (installer, désinstaller, statut)

--- a/_i18n/messages_hi.properties
+++ b/_i18n/messages_hi.properties
@@ -634,6 +634,7 @@ error.parseError=त्रुटि: {0}
 error.jsonParseError=JSON पार्स त्रुटि
 error.cfServicePlansRequired=सेवा योजना(ओं) को निर्दिष्ट किया जाना चाहिए
 error.cfTargetUnavailable=वर्तमान स्थान या संगठन निर्धारित करने में असमर्थ
+error.cfNotLoggedIn=Cloud Foundry में लॉग इन नहीं है। कृपया पहले 'cf login' चलाएँ, फिर इस ऑपरेशन को पुनः आज़माएँ
 error.cfServiceInstanceNameRequired=सेवा इंस्टेंस का नाम एक गैर-खाली स्ट्रिंग होना चाहिए
 error.cfHanaInstanceGuidRequired=HANA इंस्टेंस GUID एक गैर-खाली स्ट्रिंग होना चाहिए
 error.cfHanaInstanceNameRequired=HANA इंस्टेंस का नाम एक गैर-खाली स्ट्रिंग होना चाहिए
@@ -1639,3 +1640,4 @@ cds.swagger.error=Warning: Swagger UI setup failed: {0}
 
 rowsAffected=प्रभावित पंक्तियाँ: {0}
 stmtExecutedNoResultSet=कथन सफलतापूर्वक निष्पादित (कोई परिणाम सेट नहीं)।
+vscode=hana-cli VSCode एक्सटेंशन प्रबंधित करें (इंस्टॉल, अनइंस्टॉल, स्थिति)

--- a/_i18n/messages_ja.properties
+++ b/_i18n/messages_ja.properties
@@ -633,7 +633,8 @@ error.massConvertFailed=Error in massConvert: {0}
 error.parseError=Error: {0}
 error.jsonParseError=JSON parse error
 error.cfServicePlansRequired=Service plan(s) must be specified
-error.cfTargetUnavailable=Unable to determine current space or organization\nerror.cfNotLoggedIn=Not logged in to Cloud Foundry. Please run 'cf login' first, then retry this operation
+error.cfTargetUnavailable=Unable to determine current space or organization
+error.cfNotLoggedIn=Cloud Foundry にログインしていません。まず 'cf login' を実行してから、この操作を再試行してください
 error.cfServiceInstanceNameRequired=Service instance name must be a non-empty string
 error.cfHanaInstanceGuidRequired=HANA instance GUID must be a non-empty string
 error.cfHanaInstanceNameRequired=HANA instance name must be a non-empty string
@@ -1638,3 +1639,4 @@ mcpServerStatusBuildHint=MCP server is not built. Build it first:
 
 rowsAffected=影響を受けた行数: {0}
 stmtExecutedNoResultSet=ステートメントが正常に実行されました（結果セットなし）。
+vscode=hana-cli VSCode 拡張機能を管理する（インストール、アンインストール、ステータス）

--- a/_i18n/messages_ko.properties
+++ b/_i18n/messages_ko.properties
@@ -633,7 +633,8 @@ error.massConvertFailed=Error in massConvert: {0}
 error.parseError=Error: {0}
 error.jsonParseError=JSON parse error
 error.cfServicePlansRequired=Service plan(s) must be specified
-error.cfTargetUnavailable=Unable to determine current space or organization\nerror.cfNotLoggedIn=Not logged in to Cloud Foundry. Please run 'cf login' first, then retry this operation
+error.cfTargetUnavailable=Unable to determine current space or organization
+error.cfNotLoggedIn=Cloud Foundry에 로그인되어 있지 않습니다. 먼저 'cf login'을 실행한 후 이 작업을 다시 시도하십시오
 error.cfServiceInstanceNameRequired=Service instance name must be a non-empty string
 error.cfHanaInstanceGuidRequired=HANA instance GUID must be a non-empty string
 error.cfHanaInstanceNameRequired=HANA instance name must be a non-empty string
@@ -1638,3 +1639,4 @@ mcpServerStatusBuildHint=MCP server is not built. Build it first:
 
 rowsAffected=영향받은 행: {0}
 stmtExecutedNoResultSet=문이 성공적으로 실행되었습니다 (결과 집합 없음).
+vscode=hana-cli VSCode 확장 관리 (설치, 제거, 상태)

--- a/_i18n/messages_pl.properties
+++ b/_i18n/messages_pl.properties
@@ -633,7 +633,8 @@ error.massConvertFailed=Error in massConvert: {0}
 error.parseError=Error: {0}
 error.jsonParseError=JSON parse error
 error.cfServicePlansRequired=Service plan(s) must be specified
-error.cfTargetUnavailable=Unable to determine current space or organization\nerror.cfNotLoggedIn=Not logged in to Cloud Foundry. Please run 'cf login' first, then retry this operation
+error.cfTargetUnavailable=Unable to determine current space or organization
+error.cfNotLoggedIn=Nie zalogowano do Cloud Foundry. Najpierw uruchom 'cf login', a następnie ponów tę operację
 error.cfServiceInstanceNameRequired=Service instance name must be a non-empty string
 error.cfHanaInstanceGuidRequired=HANA instance GUID must be a non-empty string
 error.cfHanaInstanceNameRequired=HANA instance name must be a non-empty string
@@ -1638,3 +1639,4 @@ mcpServerStatusBuildHint=MCP server is not built. Build it first:
 
 rowsAffected=Wierszy dotyczy: {0}
 stmtExecutedNoResultSet=Instrukcja wykonana pomyślnie (brak zestawu wyników).
+vscode=Zarządzaj rozszerzeniem VSCode hana-cli (instalacja, dezinstalacja, status)

--- a/_i18n/messages_pt.properties
+++ b/_i18n/messages_pt.properties
@@ -633,7 +633,8 @@ error.massConvertFailed=Error in massConvert: {0}
 error.parseError=Error: {0}
 error.jsonParseError=JSON parse error
 error.cfServicePlansRequired=Service plan(s) must be specified
-error.cfTargetUnavailable=Unable to determine current space or organization\nerror.cfNotLoggedIn=Not logged in to Cloud Foundry. Please run 'cf login' first, then retry this operation
+error.cfTargetUnavailable=Unable to determine current space or organization
+error.cfNotLoggedIn=Não conectado ao Cloud Foundry. Execute 'cf login' primeiro e tente a operação novamente
 error.cfServiceInstanceNameRequired=Service instance name must be a non-empty string
 error.cfHanaInstanceGuidRequired=HANA instance GUID must be a non-empty string
 error.cfHanaInstanceNameRequired=HANA instance name must be a non-empty string
@@ -1638,3 +1639,4 @@ mcpServerStatusBuildHint=MCP server is not built. Build it first:
 
 rowsAffected=Linhas afetadas: {0}
 stmtExecutedNoResultSet=Instrução executada com sucesso (sem conjunto de resultados).
+vscode=Gerenciar a extensão do VSCode do hana-cli (instalar, desinstalar, status)

--- a/_i18n/messages_zh.properties
+++ b/_i18n/messages_zh.properties
@@ -633,7 +633,8 @@ error.massConvertFailed=Error in massConvert: {0}
 error.parseError=Error: {0}
 error.jsonParseError=JSON parse error
 error.cfServicePlansRequired=Service plan(s) must be specified
-error.cfTargetUnavailable=Unable to determine current space or organization\nerror.cfNotLoggedIn=Not logged in to Cloud Foundry. Please run 'cf login' first, then retry this operation
+error.cfTargetUnavailable=Unable to determine current space or organization
+error.cfNotLoggedIn=未登录到 Cloud Foundry。请先运行 'cf login'，然后重试此操作
 error.cfServiceInstanceNameRequired=Service instance name must be a non-empty string
 error.cfHanaInstanceGuidRequired=HANA instance GUID must be a non-empty string
 error.cfHanaInstanceNameRequired=HANA instance name must be a non-empty string
@@ -1638,3 +1639,4 @@ mcpServerStatusBuildHint=MCP server is not built. Build it first:
 
 rowsAffected=受影响的行数: {0}
 stmtExecutedNoResultSet=语句执行成功（无结果集）。
+vscode=管理 hana-cli VSCode 扩展（安装、卸载、状态）


### PR DESCRIPTION
## Summary

The `vscode` command help text and `error.cfNotLoggedIn` keys existed only in the **English** bundle. `validate:i18n` failed for all 9 locales — **blocking the release gate** (discovered when the release workflow's Test Suite step failed on `Validate i18n`).

## Root cause

When `error.cfNotLoggedIn` was originally introduced (with the CF-login work), the locale files were left in a broken state:
- **7 locales** (de, es, ja, ko, pl, pt, zh) had it appended as a **literal** `\nerror.cfNotLoggedIn=…` onto the end of the `error.cfTargetUnavailable` value — a real newline was never inserted, so it parsed as trailing garbage on `cfTargetUnavailable`, not as its own key.
- **fr, hi** never had `error.cfNotLoggedIn` at all.
- **None** of the 9 had the `vscode` key.

## Fix

- Split the polluted `error.cfTargetUnavailable` lines into two proper keys (cleaning the trailing literal `\n…`).
- Add `error.cfNotLoggedIn` where missing (fr/hi).
- Add translated `vscode` command help to every locale.

Each locale now has exactly one `error.cfTargetUnavailable`, one `error.cfNotLoggedIn`, and one `vscode` key.

## Verification
- ✅ `npm run validate:i18n` → **All i18n validations passed!** (exit 0)
- ✅ `eslint` clean; `test:ci` **550 passing**

Unblocks the pending `4.202607.0` release.