### PR TITLE
chore: release v4.202607.0

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,20 @@
 [
     {
+        "date": "2026-07-11",
+        "version": "4.202607.0",
+        "Added": [
+            "VS Code extension now ships a self-contained, OS-portable .vsix via the npm package (installable through hana-cli vscode install) — bundles the web UI and uses Node built-in node:sqlite, no native binaries (#159)"
+        ],
+        "Changed": [
+            "Upgrade to CAP 10 (@sap/cds 10) with cds-10-native drivers @cap-js/hana 3, @cap-js/sqlite 3, @cap-js/postgres 3, @cap-js/telemetry 2; remove incompatible @sap/cds-hana (#160)",
+            "TypeScript 7 for the VS Code extension and MCP server; consolidated dependency updates across all subprojects (#160, #162)",
+            "Group B major dependency upgrades: glob 13, @vscode/test-electron 3, vue-tsc 3, vue-router 5, csv-parse 7, js-yaml 5, inquirer 14 (#162)"
+        ],
+        "Fixed": [
+            "Add missing vscode + error.cfNotLoggedIn i18n keys across all 9 locales (#163)"
+        ]
+    },
+    {
         "date": "2026-05-14",
         "version": "4.202605.2",
         "Added": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [4.202607.0] - 2026-07-11
+
+**Added**
+
+- VS Code extension now ships a self-contained, OS-portable .vsix via the npm package (installable through hana-cli vscode install) — bundles the web UI and uses Node built-in node:sqlite, no native binaries (#159)
+
+**Changed**
+
+- Upgrade to CAP 10 (@sap/cds 10) with cds-10-native drivers @cap-js/hana 3, @cap-js/sqlite 3, @cap-js/postgres 3, @cap-js/telemetry 2; remove incompatible @sap/cds-hana (#160)
+- TypeScript 7 for the VS Code extension and MCP server; consolidated dependency updates across all subprojects (#160, #162)
+- Group B major dependency upgrades: glob 13, @vscode/test-electron 3, vue-tsc 3, vue-router 5, csv-parse 7, js-yaml 5, inquirer 14 (#162)
+
+**Fixed**
+
+- Add missing vscode + error.cfNotLoggedIn i18n keys across all 9 locales (#163)
+
 ## [4.202605.2] - 2026-05-14
 
 **Added**

--- a/mcp-server/npm-shrinkwrap.json
+++ b/mcp-server/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hana-cli-mcp-server",
-  "version": "1.202605.2",
+  "version": "1.202607.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hana-cli-mcp-server",
-      "version": "1.202605.2",
+      "version": "1.202607.0",
       "license": "SEE LICENSE IN ../LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hana-cli-mcp-server",
-  "version": "1.202605.2",
+  "version": "1.202607.0",
   "description": "MCP Server for HANA CLI Tool",
   "type": "module",
   "main": "build/index.js",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "hana-cli",
-  "version": "4.202605.2",
+  "version": "4.202607.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hana-cli",
-      "version": "4.202605.2",
+      "version": "4.202607.0",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hana-cli",
-  "version": "4.202605.2",
+  "version": "4.202607.0",
   "description": "HANA Developer Command Line Interface",
   "main": "index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/SAP-samples/hana-developer-cli-tool-example",
     "source": "github"
   },
-  "version": "4.202605.2",
+  "version": "4.202607.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "hana-cli",
-      "version": "4.202605.2",
+      "version": "4.202607.0",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {


### PR DESCRIPTION
## Release v4.202607.0

Version bump + changelog for the `4.202607.0` release.

### Why a PR (not the dispatch button)
The `Release hana-cli` workflow's `workflow_dispatch` path runs a `prepare` job that **pushes the version-bump commit directly to `main`** — which the branch-protection rulesets reject (`GH013: Repository rule violations`). So the bump is done here as a PR instead.

**After this merges**, pushing the `v4.202607.0` tag triggers the workflow's **tag path** (`resolve-version → publish`), which does *not* push to main and publishes to npm + creates the GitHub release + MCP registry cleanly.

### What's in this release
- **Added:** self-contained, OS-portable VS Code `.vsix` shipped via npm — `hana-cli vscode install`, bundled web UI, `node:sqlite`, no native binaries (#159)
- **Changed:** CAP 10 (`@sap/cds` 10) + cds-10-native drivers, removed `@sap/cds-hana` (#160)
- **Changed:** TypeScript 7 for extension + mcp-server; consolidated dependency updates (#160, #162)
- **Changed:** Group B majors — glob 13, @vscode/test-electron 3, vue-tsc 3, vue-router 5, csv-parse 7, js-yaml 5, inquirer 14 (#162)
- **Fixed:** missing `vscode` + `error.cfNotLoggedIn` i18n keys across all 9 locales (#163)

### Files
`package.json`, `npm-shrinkwrap.json`, `server.json`, `mcp-server/package.json`, `mcp-server/npm-shrinkwrap.json` → `4.202607.0` (mcp-server → `1.202607.0`); `CHANGELOG.json` / `CHANGELOG.md` updated.

### Follow-up note
Consider updating the release workflow so `workflow_dispatch` opens a release PR (or adds a bypass actor) instead of pushing to `main` — the current dispatch path can't succeed under the active rulesets.