### PR TITLE
fix(vscode): propagate container schema for env-var connections

### DIFF
--- a/tests/utils/connections.Test.js
+++ b/tests/utils/connections.Test.js
@@ -422,6 +422,56 @@ describe('connections.js - Connection Options (Isolated Tests)', () => {
     })
 })
 
+describe('connections.js - Direct (env var) Connection', () => {
+    const saved = {}
+    const ENV_KEYS = [
+        'HANA_CLI_HOST', 'HANA_CLI_PORT', 'HANA_CLI_USER',
+        'HANA_CLI_PASSWORD', 'HANA_CLI_DATABASE', 'HANA_CLI_SCHEMA'
+    ]
+
+    beforeEach(() => {
+        for (const k of ENV_KEYS) { saved[k] = process.env[k]; delete process.env[k] }
+        process.env.HANA_CLI_HOST = 'db.example.com'
+        process.env.HANA_CLI_PORT = '443'
+        process.env.HANA_CLI_USER = 'CONTAINER_RT'
+        process.env.HANA_CLI_PASSWORD = 'secret'
+        process.env.HANA_CLI_DATABASE = 'SYSTEMDB'
+    })
+
+    afterEach(() => {
+        for (const k of ENV_KEYS) {
+            if (saved[k] === undefined) { delete process.env[k] }
+            else { process.env[k] = saved[k] }
+        }
+    })
+
+    it('should build a direct connection from HANA_CLI_* env vars', async () => {
+        const connections = await import('../../utils/connections.js')
+        const options = await connections.getConnOptions({})
+        expect(options.hana.host).to.equal('db.example.com')
+        expect(options.hana.port).to.equal(443)
+        expect(options.hana.user).to.equal('CONTAINER_RT')
+        expect(options.hana.database).to.equal('SYSTEMDB')
+    })
+
+    it('should NOT set schema when HANA_CLI_SCHEMA is unset', async () => {
+        // Regression guard: without a schema, setSchema() skips SET SCHEMA and
+        // CURRENT_SCHEMA stays the empty HDI runtime user schema.
+        const connections = await import('../../utils/connections.js')
+        const options = await connections.getConnOptions({})
+        expect(options.hana).to.not.have.property('schema')
+    })
+
+    it('should propagate HANA_CLI_SCHEMA into the connection options', async () => {
+        // The fix: propagating the container schema makes createConnection issue
+        // SET SCHEMA on connect, so schema-filtered commands (tables, views) work.
+        process.env.HANA_CLI_SCHEMA = 'MY_CONTAINER'
+        const connections = await import('../../utils/connections.js')
+        const options = await connections.getConnOptions({})
+        expect(options.hana.schema).to.equal('MY_CONTAINER')
+    })
+})
+
 describe('connections.js - Module Exports', () => {
     let connections
     

--- a/utils/connections.js
+++ b/utils/connections.js
@@ -298,6 +298,12 @@ export async function getConnOptions(prompts) {
                 database: process.env.HANA_CLI_DATABASE || 'SYSTEMDB',
             }
         };
+        // Propagate the container/default schema so setSchema() issues SET SCHEMA on
+        // connect. Without this, CURRENT_SCHEMA stays the (empty) HDI runtime user
+        // schema and schema-filtered commands (tables, views, ...) return no rows.
+        if (process.env.HANA_CLI_SCHEMA) {
+            directConnection.hana.schema = process.env.HANA_CLI_SCHEMA;
+        }
         base.debug('Using direct database connection from MCP context');
         return directConnection;
     }

--- a/vscode-extension/src/server/lifecycle.ts
+++ b/vscode-extension/src/server/lifecycle.ts
@@ -109,7 +109,14 @@ export function injectConnection(conn: HanaConnection): void {
   process.env.HANA_CLI_USER = conn.user
   process.env.HANA_CLI_PASSWORD = conn.password
   process.env.HANA_CLI_DATABASE = 'SYSTEMDB'
+  // Propagate the container schema so hana-cli issues SET SCHEMA on connect.
+  // Without it, CURRENT_SCHEMA stays the empty HDI runtime user schema and
+  // schema-filtered commands (tables, views, ...) return no rows. Clear any
+  // stale value when the new connection has no schema, to avoid leaking it
+  // across connection switches.
   if (conn.schema) {
     process.env.HANA_CLI_SCHEMA = conn.schema
+  } else {
+    delete process.env.HANA_CLI_SCHEMA
   }
 }


### PR DESCRIPTION
## Problem

In the VSCode extension, **Tables** (and other schema-filtered commands) show *"No data available"*, while **System Info** works. Database connectivity is fine — it's specifically commands that filter by schema that fail.

## Root cause

The extension connects to HANA via `HANA_CLI_*` environment variables. `injectConnection()` set `process.env.HANA_CLI_SCHEMA`, but **nothing in hana-cli read it** — the direct connection object built in `connections.js` had no `schema` field.

The failure chain:
1. No `schema` in the connection options → `sap-hdb-promisfied`'s `setSchema()` skips its `SET SCHEMA` call on connect.
2. The session's `CURRENT_SCHEMA` stays the HDI **runtime user** schema (`..._RT`), which contains no tables.
3. Tables sends `schema: '**CURRENT_SCHEMA**'`, which resolves to that empty schema → **0 rows**.
4. System Info works because `/hana` runs fixed system-view SQL and never filters by schema.

The web UI works because it resolves via `default-env.json`/`.cdsrc-private.json`, which carry `credentials.schema` = the container schema.

## Fix

- **`utils/connections.js`** — propagate `HANA_CLI_SCHEMA` into the direct connection so `SET SCHEMA` runs on connect.
- **`vscode-extension/src/server/lifecycle.ts`** — always set or clear `HANA_CLI_SCHEMA` to avoid a stale schema leaking across connection switches.
- **`tests/utils/connections.Test.js`** — 3 new tests covering the direct-connection env-var path (including a regression guard for the missing-schema case).

## Verification

- Reproduced empirically against a running server: env-var connection without schema → `CURRENT_SCHEMA = ..._RT`, Tables = **0 rows**. With schema propagated → `CURRENT_SCHEMA = <container>`, Tables = **72 rows**.
- New unit tests pass; ESLint + `tsc --noEmit` clean.
- Full suite: 2199 passing. The 13 failures are pre-existing (UI/wdio browser tests + env-dependent server tests) and confirmed to fail identically on baseline with these changes stashed.