### PR TITLE
fix(vscode): resolve HANA connection from config in subfolders

### DIFF
--- a/bin/vscode.js
+++ b/bin/vscode.js
@@ -89,6 +89,50 @@ function findVsix() {
   return vsix ? join(VSIX_DIR, vsix) : null
 }
 
+/**
+ * Compare two semver-ish version strings numerically.
+ * Missing segments are treated as zero (e.g. "1" === "1.0.0").
+ * @param {string} a
+ * @param {string} b
+ * @returns {number} -1 if a<b, 0 if equal, 1 if a>b
+ */
+export function compareVersions(a, b) {
+  const pa = String(a).split('.').map(n => parseInt(n, 10) || 0)
+  const pb = String(b).split('.').map(n => parseInt(n, 10) || 0)
+  const len = Math.max(pa.length, pb.length)
+  for (let i = 0; i < len; i++) {
+    const na = pa[i] || 0
+    const nb = pb[i] || 0
+    if (na > nb) return 1
+    if (na < nb) return -1
+  }
+  return 0
+}
+
+/**
+ * Extract the version from a hana-cli .vsix filename or path.
+ * @param {string} vsixPath - e.g. "hana-cli-0.1.7.vsix"
+ * @returns {string|null} the version string, or null if not found
+ */
+export function parseVsixVersion(vsixPath) {
+  if (!vsixPath) return null
+  const match = /(\d+\.\d+\.\d+)\.vsix$/.exec(String(vsixPath))
+  return match ? match[1] : null
+}
+
+/**
+ * Extract the version from a `code --list-extensions --show-versions` line.
+ * @param {string} line - e.g. "SAP-samples.hana-cli@0.1.6"
+ * @returns {string|null} the version string, or null if not found
+ */
+export function parseInstalledVersion(line) {
+  if (!line) return null
+  const idx = line.indexOf('@')
+  if (idx === -1) return null
+  const version = line.slice(idx + 1).trim()
+  return version || null
+}
+
 export function handler(argv) {
   const action = argv.action || 'status'
   const codeCli = detectCodeCli(argv.insiders)
@@ -129,7 +173,8 @@ function installExtension(codeCli) {
   if (vsixPath) {
     console.log(`Installing extension from: ${vsixPath}`)
     try {
-      const output = runCmd(codeCli, ['--install-extension', vsixPath])
+      // --force upgrades an already-installed extension in place (no uninstall needed)
+      const output = runCmd(codeCli, ['--install-extension', vsixPath, '--force'])
       console.log(output.trim())
       console.log('Extension installed successfully.')
     } catch (err) {
@@ -162,7 +207,8 @@ function uninstallExtension(codeCli) {
 }
 
 /**
- * Check if the extension is installed.
+ * Check if the extension is installed, and whether it is up to date
+ * relative to the packaged .vsix (the version this hana-cli ships with).
  * @param {string} codeCli
  */
 function checkStatus(codeCli) {
@@ -170,11 +216,41 @@ function checkStatus(codeCli) {
     const output = runCmd(codeCli, ['--list-extensions', '--show-versions'])
     const lines = output.split('\n')
     const match = lines.find(line => line.toLowerCase().includes('hana-cli'))
-    if (match) {
-      console.log(`Extension installed: ${match.trim()}`)
-    } else {
+
+    const vsixPath = findVsix()
+    const packagedVersion = parseVsixVersion(vsixPath || '')
+
+    if (!match) {
       console.log('Extension is not installed.')
+      if (packagedVersion) {
+        console.log(`  A packaged version (${packagedVersion}) is available.`)
+      }
       console.log(`  To install: hana-cli vscode install`)
+      return
+    }
+
+    const installedVersion = parseInstalledVersion(match)
+    console.log(`Extension installed: ${match.trim()}`)
+
+    if (!packagedVersion) {
+      // No local .vsix to compare against — installed is all we can report.
+      return
+    }
+
+    if (!installedVersion) {
+      console.log(`  Packaged version available: ${packagedVersion}`)
+      return
+    }
+
+    const cmp = compareVersions(installedVersion, packagedVersion)
+    if (cmp < 0) {
+      console.log('')
+      console.log(`  Update available: ${installedVersion} -> ${packagedVersion}`)
+      console.log(`  To update: hana-cli vscode install`)
+    } else if (cmp > 0) {
+      console.log(`  Installed version is newer than the packaged .vsix (${packagedVersion}).`)
+    } else {
+      console.log(`  Up to date (matches packaged version ${packagedVersion}).`)
     }
   } catch (err) {
     console.error(`Failed to check extension status: ${err.message}`)

--- a/tests/vscodeVersion.Test.js
+++ b/tests/vscodeVersion.Test.js
@@ -1,0 +1,53 @@
+// @ts-check
+/**
+ * @module vscodeVersion Tests - Unit tests for the pure version helpers in bin/vscode.js
+ *
+ * These validate the semver comparison and .vsix filename parsing used by
+ * `hana-cli vscode status` to tell the user whether their installed extension
+ * is up to date with the packaged .vsix.
+ */
+import { assert } from './base.js'
+import { compareVersions, parseVsixVersion, parseInstalledVersion } from '../bin/vscode.js'
+
+describe('vscode version helpers', function () {
+
+    describe('compareVersions', function () {
+        it('returns 0 for equal versions', function () {
+            assert.strictEqual(compareVersions('0.1.7', '0.1.7'), 0)
+        })
+        it('returns -1 when first is older', function () {
+            assert.strictEqual(compareVersions('0.1.6', '0.1.7'), -1)
+        })
+        it('returns 1 when first is newer', function () {
+            assert.strictEqual(compareVersions('0.2.0', '0.1.7'), 1)
+        })
+        it('compares major/minor/patch numerically, not lexically', function () {
+            assert.strictEqual(compareVersions('0.1.10', '0.1.9'), 1)
+        })
+        it('treats missing segments as zero', function () {
+            assert.strictEqual(compareVersions('1', '1.0.0'), 0)
+        })
+    })
+
+    describe('parseVsixVersion', function () {
+        it('extracts the version from a hana-cli .vsix filename', function () {
+            assert.strictEqual(parseVsixVersion('hana-cli-0.1.7.vsix'), '0.1.7')
+        })
+        it('extracts from a full path', function () {
+            assert.strictEqual(parseVsixVersion('/some/dir/hana-cli-1.2.3.vsix'), '1.2.3')
+        })
+        it('returns null when no version is present', function () {
+            assert.strictEqual(parseVsixVersion('hana-cli.vsix'), null)
+        })
+    })
+
+    describe('parseInstalledVersion', function () {
+        it('extracts the version from --list-extensions --show-versions line', function () {
+            assert.strictEqual(parseInstalledVersion('SAP-samples.hana-cli@0.1.6'), '0.1.6')
+        })
+        it('returns null when there is no @version suffix', function () {
+            assert.strictEqual(parseInstalledVersion('SAP-samples.hana-cli'), null)
+        })
+    })
+
+})

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -44,6 +44,20 @@ On activation the extension automatically resolves a HANA connection from your w
 
 The current connection is shown in the status bar.
 
+### Projects in a subfolder
+
+Your connection config often does not live at the workspace root — for example a CAP project kept in a `cap/` subfolder. The extension scans subfolders (skipping `node_modules`, `.git`, and build output) for a `.cdsrc-private.json`, `default-env.json`, or a CAP `package.json`, and resolves from the folder it finds. When more than one candidate exists (e.g. a monorepo), it prompts you to pick which project to connect.
+
+To point the extension at a specific folder and skip auto-detection, set **`hana-cli.projectPath`** in your workspace settings (relative to the workspace root, or an absolute path):
+
+```json
+{
+  "hana-cli.projectPath": "cap"
+}
+```
+
+Leave it empty (the default) to auto-detect.
+
 ## Requirements
 
 - Visual Studio Code `^1.85.0`

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "hana-cli",
   "displayName": "hana-cli Tools for SAP HANA",
   "description": "Visual editors and database tools for SAP HANA powered by hana-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publisher": "SAP-samples",
   "icon": "icon.png",
   "license": "Apache-2.0",
@@ -45,6 +45,16 @@
     }
   },
   "contributes": {
+    "configuration": {
+      "title": "hana-cli",
+      "properties": {
+        "hana-cli.projectPath": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Path to the folder containing your HANA connection config (`.cdsrc-private.json`, `default-env.json`, or a CAP `package.json`). Relative paths are resolved against the workspace root. Leave empty to auto-detect — the extension scans subfolders (e.g. `cap/`) and prompts when more than one project is found."
+        }
+      }
+    },
     "commands": [
       {
         "command": "hana-cli.openTools",

--- a/vscode-extension/src/connection/discovery.ts
+++ b/vscode-extension/src/connection/discovery.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+export type ConfigKind = 'cap' | 'cdsrc-private' | 'default-env' | 'default-env-admin'
+
+export interface ConfigCandidate {
+  /** Absolute path to the directory containing connection config. */
+  dir: string
+  /** Which config markers were found in this directory. */
+  kinds: ConfigKind[]
+  /** Directory depth relative to the scan root (root = 0). */
+  depth: number
+}
+
+const IGNORED_DIRS = new Set(['node_modules', '.git', 'dist', 'out', 'gen', '.vscode'])
+
+/**
+ * Determine which connection-config markers exist directly inside `dir`.
+ * A folder is a CAP project when it has a package.json that depends on
+ * @sap/cds (or @sap/cds-dk). Credentials markers are .cdsrc-private.json,
+ * default-env.json and default-env-admin.json.
+ */
+function classifyDir(dir: string): ConfigKind[] {
+  const kinds: ConfigKind[] = []
+
+  const pkgPath = path.join(dir, 'package.json')
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
+      const deps = { ...pkg.dependencies, ...pkg.devDependencies }
+      if (deps['@sap/cds'] || deps['@sap/cds-dk']) {
+        kinds.push('cap')
+      }
+    } catch {
+      // Unparseable package.json — ignore, not a usable CAP marker
+    }
+  }
+
+  if (fs.existsSync(path.join(dir, '.cdsrc-private.json'))) {
+    kinds.push('cdsrc-private')
+  }
+  if (fs.existsSync(path.join(dir, 'default-env.json'))) {
+    kinds.push('default-env')
+  }
+  if (fs.existsSync(path.join(dir, 'default-env-admin.json'))) {
+    kinds.push('default-env-admin')
+  }
+
+  return kinds
+}
+
+/**
+ * Recursively scan `rootDir` (bounded by `maxDepth`) for directories that
+ * contain HANA connection configuration. Skips node_modules/.git/build output.
+ * Results are sorted shallowest-first so the caller can prefer the closest
+ * project to the workspace root.
+ *
+ * @param rootDir absolute path of the workspace folder to scan
+ * @param maxDepth maximum directory depth to descend (root = 0)
+ */
+export function discoverConfigDirs(rootDir: string, maxDepth = 3): ConfigCandidate[] {
+  const results: ConfigCandidate[] = []
+
+  const walk = (dir: string, depth: number): void => {
+    if (depth > maxDepth) return
+
+    const kinds = classifyDir(dir)
+    if (kinds.length > 0) {
+      results.push({ dir, kinds, depth })
+    }
+
+    if (depth === maxDepth) return
+
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      if (IGNORED_DIRS.has(entry.name)) continue
+      if (entry.name.startsWith('.')) continue
+      walk(path.join(dir, entry.name), depth + 1)
+    }
+  }
+
+  walk(rootDir, 0)
+
+  // Shallowest first; stable tiebreak by path for determinism.
+  results.sort((a, b) => a.depth - b.depth || a.dir.localeCompare(b.dir))
+  return results
+}

--- a/vscode-extension/src/connection/resolver.ts
+++ b/vscode-extension/src/connection/resolver.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode'
+import * as fs from 'fs'
+import * as path from 'path'
 import { execFile } from 'child_process'
 
 const log = vscode.window.createOutputChannel('hana-cli resolver', { log: true })
@@ -20,17 +22,31 @@ export type ResolveResult =
   | { status: 'no-config' }
 
 /**
- * Resolves a HANA connection from workspace files using a 3-step strategy:
- * 1. CAP: .cdsrc-private.json credentials or CF binding (if @sap/cds is a project dependency)
- * 2. Workspace: default-env.json VCAP_SERVICES
- * 3. Returns no-config (caller should fall back to SecretStorage)
+ * Resolves a HANA connection from a workspace folder, using its root as the
+ * config directory. Retained for backwards compatibility; prefer
+ * {@link resolveConnectionInDir} when the config lives in a subfolder.
  */
 export async function resolveConnection(
   workspaceFolder: vscode.WorkspaceFolder
 ): Promise<ResolveResult> {
-  log.info(`Resolving connection for workspace: ${workspaceFolder.uri.fsPath}`)
+  return resolveConnectionInDir(workspaceFolder.uri.fsPath)
+}
 
-  const capResult = await resolveFromCAP(workspaceFolder)
+/**
+ * Resolves a HANA connection from files in a specific directory using a
+ * 3-step strategy:
+ * 1. CAP: .cdsrc-private.json credentials or CF binding (if @sap/cds is a project dependency)
+ * 2. default-env.json VCAP_SERVICES
+ * 3. Returns no-config (caller should fall back to SecretStorage)
+ *
+ * @param dir absolute path of the directory holding the connection config.
+ *   This is used as the cwd for `cds env` / `cf service-key`, so it must be
+ *   the CAP project directory (e.g. a `cap/` subfolder), not the workspace root.
+ */
+export async function resolveConnectionInDir(dir: string): Promise<ResolveResult> {
+  log.info(`Resolving connection in directory: ${dir}`)
+
+  const capResult = await resolveFromCAP(dir)
   if (capResult.status !== 'no-config') {
     if (capResult.status === 'connected') {
       log.info(`Resolved via ${capResult.connection.source}: ${capResult.connection.user}@${capResult.connection.host}:${capResult.connection.port}`)
@@ -38,13 +54,13 @@ export async function resolveConnection(
     return capResult
   }
 
-  const envConn = await resolveFromDefaultEnv(workspaceFolder)
+  const envConn = await resolveFromDefaultEnv(dir)
   if (envConn) {
     log.info(`Resolved via default-env: ${envConn.user}@${envConn.host}:${envConn.port}`)
     return { status: 'connected', connection: envConn }
   }
 
-  log.info('No connection resolved from workspace files')
+  log.info(`No connection resolved from files in: ${dir}`)
   return { status: 'no-config' }
 }
 
@@ -185,13 +201,10 @@ function resolveCdsBinding(binding: Record<string, unknown>, cwd: string): Promi
   })
 }
 
-async function resolveFromCAP(
-  workspaceFolder: vscode.WorkspaceFolder
-): Promise<ResolveResult> {
+async function resolveFromCAP(dir: string): Promise<ResolveResult> {
   try {
-    const packageJsonUri = vscode.Uri.joinPath(workspaceFolder.uri, 'package.json')
-    const packageJsonData = await vscode.workspace.fs.readFile(packageJsonUri)
-    const packageJson = JSON.parse(Buffer.from(packageJsonData).toString('utf-8'))
+    const packageJsonPath = path.join(dir, 'package.json')
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
 
     const deps = { ...packageJson.dependencies, ...packageJson.devDependencies }
     if (!deps['@sap/cds'] && !deps['@sap/cds-dk']) {
@@ -200,9 +213,8 @@ async function resolveFromCAP(
     }
 
     log.info('CAP project detected, looking for .cdsrc-private.json')
-    const cdsrcUri = vscode.Uri.joinPath(workspaceFolder.uri, '.cdsrc-private.json')
-    const cdsrcData = await vscode.workspace.fs.readFile(cdsrcUri)
-    const cdsrc = JSON.parse(Buffer.from(cdsrcData).toString('utf-8'))
+    const cdsrcPath = path.join(dir, '.cdsrc-private.json')
+    const cdsrc = JSON.parse(fs.readFileSync(cdsrcPath, 'utf-8'))
 
     const entry = extractCdsBindingOrCredentials(cdsrc)
     if (!entry) {
@@ -218,10 +230,9 @@ async function resolveFromCAP(
       return { status: 'no-config' }
     }
 
-    // Binding — resolve via cds env or cf service-key
+    // Binding — resolve via cds env or cf service-key, using the config dir as cwd
     const instanceName = (entry.value.instance as string) || undefined
-    const cwd = workspaceFolder.uri.fsPath
-    const resolved = await resolveCdsBinding(entry.value, cwd)
+    const resolved = await resolveCdsBinding(entry.value, dir)
     if (resolved) {
       const conn = credsToConnection(resolved, instanceName)
       if (conn) return { status: 'connected', connection: conn }
@@ -237,13 +248,10 @@ async function resolveFromCAP(
   }
 }
 
-async function resolveFromDefaultEnv(
-  workspaceFolder: vscode.WorkspaceFolder
-): Promise<HanaConnection | null> {
+async function resolveFromDefaultEnv(dir: string): Promise<HanaConnection | null> {
   try {
-    const defaultEnvUri = vscode.Uri.joinPath(workspaceFolder.uri, 'default-env.json')
-    const data = await vscode.workspace.fs.readFile(defaultEnvUri)
-    const env = JSON.parse(Buffer.from(data).toString('utf-8'))
+    const defaultEnvPath = path.join(dir, 'default-env.json')
+    const env = JSON.parse(fs.readFileSync(defaultEnvPath, 'utf-8'))
 
     const hanaServices = env?.VCAP_SERVICES?.hana ?? env?.VCAP_SERVICES?.['hana-cloud'] ?? []
     const creds = hanaServices[0]?.credentials

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,9 +1,11 @@
 import * as vscode from 'vscode'
+import * as path from 'path'
 import { startServer, stopServer, scheduleShutdown, injectConnection } from './server/lifecycle.js'
 import { registerToolsPanel } from './editors/toolsPanel.js'
 import { CalcViewEditorProvider } from './editors/calcViewEditor.js'
 import { ArtifactInspectorProvider } from './editors/artifactInspector.js'
-import { resolveConnection, type HanaConnection, type ResolveResult } from './connection/resolver.js'
+import { resolveConnectionInDir, type HanaConnection, type ResolveResult } from './connection/resolver.js'
+import { discoverConfigDirs } from './connection/discovery.js'
 import { ConnectionManager } from './connection/manager.js'
 import { createConnectionStatusBar, updateStatus } from './connection/statusBar.js'
 
@@ -24,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const folders = vscode.workspace.workspaceFolders
     if (folders && folders.length > 0) {
-      resolveConnection(folders[0]).then((result) => {
+      autoResolveConnection(folders[0]).then((result) => {
         if (result.status === 'connected') {
           currentConnection = result.connection
           injectConnection(result.connection)
@@ -102,6 +104,67 @@ export function activate(context: vscode.ExtensionContext) {
 
 export async function ensureServer(context: vscode.ExtensionContext): Promise<number> {
   return startServer(context, currentConnection ?? undefined)
+}
+
+/**
+ * Auto-resolve the workspace HANA connection.
+ *
+ * The connection config (`.cdsrc-private.json`, `default-env.json`, or a CAP
+ * `package.json`) may not live at the workspace root — it is common for the
+ * CAP project to sit in a subfolder (e.g. `cap/`). This:
+ *   1. Honors an explicit `hana-cli.projectPath` setting when present.
+ *   2. Otherwise scans the workspace for config-bearing directories.
+ *   3. Prompts via QuickPick when more than one candidate is found.
+ */
+async function autoResolveConnection(
+  workspaceFolder: vscode.WorkspaceFolder
+): Promise<ResolveResult> {
+  const rootPath = workspaceFolder.uri.fsPath
+
+  // 1. Explicit override wins.
+  const override = vscode.workspace
+    .getConfiguration('hana-cli')
+    .get<string>('projectPath')
+  if (override && override.trim()) {
+    const dir = path.isAbsolute(override) ? override : path.join(rootPath, override)
+    outputChannel.appendLine(`Using configured hana-cli.projectPath: ${dir}`)
+    return resolveConnectionInDir(dir)
+  }
+
+  // 2. Discover config-bearing directories (bounded scan).
+  const candidates = discoverConfigDirs(rootPath)
+  if (candidates.length === 0) {
+    // Fall back to resolving the root itself (preserves prior behavior).
+    return resolveConnectionInDir(rootPath)
+  }
+
+  // 3. Single candidate → use it directly.
+  if (candidates.length === 1) {
+    return resolveConnectionInDir(candidates[0].dir)
+  }
+
+  // 4. Multiple candidates → let the user choose.
+  const picked = await vscode.window.showQuickPick(
+    candidates.map((c) => {
+      const rel = path.relative(rootPath, c.dir) || '.'
+      return {
+        label: rel,
+        description: c.kinds.join(', '),
+        detail: c.dir,
+        dir: c.dir
+      }
+    }),
+    {
+      title: 'hana-cli: Select the project to connect',
+      placeHolder: 'Multiple HANA connection configs found — pick one'
+    }
+  )
+
+  if (!picked) {
+    // User dismissed the picker — default to the shallowest candidate.
+    return resolveConnectionInDir(candidates[0].dir)
+  }
+  return resolveConnectionInDir(picked.dir)
 }
 
 export function trackWebviewOpen(): void {

--- a/vscode-extension/test/suite/discovery.test.ts
+++ b/vscode-extension/test/suite/discovery.test.ts
@@ -1,0 +1,80 @@
+import * as assert from 'assert'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { discoverConfigDirs } from '../../src/connection/discovery.js'
+
+let tmpRoot: string
+
+function write(rel: string, contents: string): void {
+  const full = path.join(tmpRoot, rel)
+  fs.mkdirSync(path.dirname(full), { recursive: true })
+  fs.writeFileSync(full, contents)
+}
+
+suite('Connection config discovery', () => {
+  setup(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hana-cli-discovery-'))
+  })
+
+  teardown(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  test('finds a CAP project config in a subfolder', () => {
+    // Mirrors the cloud-cap-hana-swapi layout: config lives in cap/, not root
+    write('cap/package.json', JSON.stringify({ dependencies: { '@sap/cds': '^10.0.3' } }))
+    write('cap/.cdsrc-private.json', JSON.stringify({ requires: { db: { credentials: { host: 'h' } } } }))
+
+    const found = discoverConfigDirs(tmpRoot, 3)
+
+    assert.strictEqual(found.length, 1, 'expected exactly one candidate')
+    assert.strictEqual(found[0].dir, path.join(tmpRoot, 'cap'))
+    assert.ok(found[0].kinds.includes('cap'), 'candidate should be flagged as cap')
+  })
+
+  test('finds a default-env.json in a subfolder', () => {
+    write('cap/default-env.json', JSON.stringify({ VCAP_SERVICES: {} }))
+
+    const found = discoverConfigDirs(tmpRoot, 3)
+
+    assert.strictEqual(found.length, 1)
+    assert.strictEqual(found[0].dir, path.join(tmpRoot, 'cap'))
+    assert.ok(found[0].kinds.includes('default-env'))
+  })
+
+  test('prefers the shallowest candidate first (root before subfolder)', () => {
+    write('default-env.json', JSON.stringify({ VCAP_SERVICES: {} }))
+    write('cap/default-env.json', JSON.stringify({ VCAP_SERVICES: {} }))
+
+    const found = discoverConfigDirs(tmpRoot, 3)
+
+    assert.ok(found.length >= 2)
+    assert.strictEqual(found[0].dir, tmpRoot, 'root must sort before subfolder')
+  })
+
+  test('ignores node_modules and .git', () => {
+    write('node_modules/some-pkg/default-env.json', JSON.stringify({ VCAP_SERVICES: {} }))
+    write('.git/default-env.json', JSON.stringify({ VCAP_SERVICES: {} }))
+
+    const found = discoverConfigDirs(tmpRoot, 3)
+
+    assert.strictEqual(found.length, 0, 'must not descend into node_modules or .git')
+  })
+
+  test('respects the depth limit', () => {
+    write('a/b/c/d/default-env.json', JSON.stringify({ VCAP_SERVICES: {} }))
+
+    const found = discoverConfigDirs(tmpRoot, 2)
+
+    assert.strictEqual(found.length, 0, 'candidate deeper than maxDepth must be skipped')
+  })
+
+  test('does not flag a plain folder without config', () => {
+    write('srv/service.cds', 'service Foo {}')
+
+    const found = discoverConfigDirs(tmpRoot, 3)
+
+    assert.strictEqual(found.length, 0)
+  })
+})


### PR DESCRIPTION
## Problem

The VS Code extension's connection resolver only inspected the **workspace root**. CAP projects that keep their connection config in a subfolder (e.g. `cap/`) showed **"HANA: Not Connected"** even though `.cdsrc-private.json` / `default-env.json` existed one level down. The `cwd` passed to `cds env` / `cf service-key` was also the root, so binding resolution would fail there too.

Reproduced with the `cloud-cap-hana-swapi` project (config lives in `cap/`).

## Fix

- **`discovery.ts`** (new) — pure, bounded recursive scan (default depth 3) for directories containing `.cdsrc-private.json`, `default-env.json`, or a CAP `package.json`. Skips `node_modules`/`.git`/build dirs; returns candidates shallowest-first.
- **`resolver.ts`** — refactored to `resolveConnectionInDir(dir)` so it resolves any directory and uses that dir as the `cwd` for `cds env` / `cf service-key`. `resolveConnection(workspaceFolder)` kept as a thin wrapper.
- **`extension.ts`** — new `autoResolveConnection()`: honors a `hana-cli.projectPath` setting if set, otherwise scans, uses the single candidate directly, or shows a QuickPick when several exist.
- **`package.json`** — adds the `hana-cli.projectPath` configuration contribution.
- **README** — documents subfolder scanning + the new setting.

### Bonus: `hana-cli vscode status`

Enhanced to compare the **installed** extension version against the **packaged `.vsix`** and suggest updating when behind. `install` now uses `--force` so it upgrades in place (no uninstall needed).

## Testing

- `vscode-extension/test/suite/discovery.test.ts` — 6 tests (subfolder detection, shallowest-first ordering, ignore rules, depth limit). ✅
- `tests/vscodeVersion.Test.js` — 10 tests for `compareVersions` / `parseVsixVersion` / `parseInstalledVersion`. ✅
- Both `tsconfig` compiles clean (strict).
- Verified end-to-end against `cloud-cap-hana-swapi`: discovery finds `cap/` and `cds env ... --resolve-bindings` resolves credentials from that cwd → status bar shows connected.
- `vscode status` verified in both branches (up-to-date and update-available).

## Notes

- `CHANGELOG.json`/`CHANGELOG.md` intentionally untouched — this repo manages the changelog at release time via `scripts/prepare-release.js`, not per-PR.