### PR TITLE
chore(vscode): gitignore .vscode-test harness cache directory

### DIFF
--- a/vscode-extension/.gitignore
+++ b/vscode-extension/.gitignore
@@ -3,3 +3,4 @@ dist/
 webview-dist/
 _i18n/
 *.vsix
+.vscode-test/


### PR DESCRIPTION
## Problem

Running the extension test suite (`npm test` under `@vscode/test-electron`) downloads a full VS Code binary into `vscode-extension/.vscode-test/` — **6,314 files / ~906 MB**. This directory was not ignored, flooding the git working tree (~882 changes in the VS Code git window).

## Fix

Add `.vscode-test/` to `vscode-extension/.gitignore`, alongside the other build outputs (`out/`, `dist/`, `webview-dist/`, `_i18n/`, `*.vsix`). Nothing under that path was ever tracked, so nothing is orphaned.

This is the standard `@vscode/test-electron` cache location and should never be committed.